### PR TITLE
improve test setup php-ldap check

### DIFF
--- a/tests/Integration/LdapIntegrationTest.php
+++ b/tests/Integration/LdapIntegrationTest.php
@@ -45,14 +45,13 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
 
     public function setUp()
     {
-        if (!function_exists('ldap_bind')) {
+        if (empty(getenv('PLUGIN_NAME'))) {
+            $this->markTestSkipped('LDAP tests can only be run as plugin tests.');
+            return;
+        }
 
-            $runningLdapTests = !empty(getenv('PLUGIN_NAME'));
-            if($runningLdapTests) {
-                throw new \Exception("PHP not compiled w/ --with-ldap!");
-            } else {
-                $this->markTestSkipped('LDAP not setup in travis. ');
-            }
+        if (!function_exists('ldap_bind')) {
+            throw new \Exception("PHP not compiled w/ --with-ldap!");
         }
 
         if (!$this->isLdapServerRunning()) {


### PR DESCRIPTION
Currently the integration tests are skipped or throw an exception if the function `ldap_bind` is not available.

While testing the new trusty environment on travis I found that the function is available now by default. But the core test suite does not start an LDAP instance so we receive errors as the connection failes ([see build here](https://travis-ci.org/mneudert/piwik/builds/275251628)).

Changing the skip to only check the environment variable `PLUGIN_NAME` seems to nicely circumvent this problem ([see build here](https://travis-ci.org/mneudert/piwik/builds/275482424)). As this change also affects non-travis testing environments I also changed the skip message to be more generic.

[ref piwik/travis-scripts#36]