### PR TITLE
If UserUpdater method exists use it to update superuser access (to bypass password confirmation)

### DIFF
--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -186,8 +186,7 @@ class UserSynchronizer
             Access::doAsSuperUser(function () use ($usersManagerApi, $userAccessLevel, $sites, $piwikLogin) {
                 if ($userAccessLevel == 'superuser') {
                     if (method_exists('Piwik\Plugins\UsersManager\UserUpdater', 'setSuperUserAccessWithoutCurrentPassword')) {
-                        $userUpdater = new UserUpdater();
-                        $userUpdater->setSuperUserAccessWithoutCurrentPassword($piwikLogin, true);
+                        $this->userUpdater->setSuperUserAccessWithoutCurrentPassword($piwikLogin, true);
                     } else {
                         $usersManagerApi->setSuperUserAccess($piwikLogin, true);
                     }

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -185,7 +185,12 @@ class UserSynchronizer
         foreach ($userAccess as $userAccessLevel => $sites) {
             Access::doAsSuperUser(function () use ($usersManagerApi, $userAccessLevel, $sites, $piwikLogin) {
                 if ($userAccessLevel == 'superuser') {
-                    $usersManagerApi->setSuperUserAccess($piwikLogin, true);
+                    if (method_exists('Piwik\Plugins\UsersManager\UserUpdater', 'setSuperUserAccessWithoutCurrentPassword')) {
+                        $userUpdater = new UserUpdater();
+                        $userUpdater->setSuperUserAccessWithoutCurrentPassword($piwikLogin, true);
+                    } else {
+                        $usersManagerApi->setSuperUserAccess($piwikLogin, true);
+                    }
                 } else {
                     $usersManagerApi->setUserAccess($piwikLogin, $userAccessLevel, $sites);
                 }

--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -15,6 +15,7 @@ use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugins\LoginLdap\Auth\LdapAuth;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
+use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Tests\Framework\Fixture;
 
 /**
@@ -167,7 +168,8 @@ class AuthenticationTest extends LdapIntegrationTest
     public function test_LdapAuth_AuthenticatesSuccessfully_WhenAuthenticatingNormalPiwikSuperUser()
     {
         UsersManagerAPI::getInstance()->addUser('zola', 'hydra___', 'zola@shield.org', $alias = false);
-        UsersManagerAPI::getInstance()->setSuperUserAccess('zola', true);
+        $userUpdater = new UserUpdater();
+        $userUpdater->setSuperUserAccessWithoutCurrentPassword('zola', true);
 
         $ldapAuth = LdapAuth::makeConfigured();
         $ldapAuth->setLogin('zola');

--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -12,10 +12,8 @@ use Piwik\AuthResult;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Db;
-use Piwik\Piwik;
 use Piwik\Plugins\LoginLdap\Auth\LdapAuth;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
-use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Tests\Framework\Fixture;
 
 /**
@@ -168,8 +166,7 @@ class AuthenticationTest extends LdapIntegrationTest
     public function test_LdapAuth_AuthenticatesSuccessfully_WhenAuthenticatingNormalPiwikSuperUser()
     {
         UsersManagerAPI::getInstance()->addUser('zola', 'hydra___', 'zola@shield.org', $alias = false);
-        $userUpdater = new UserUpdater();
-        $userUpdater->setSuperUserAccessWithoutCurrentPassword('zola', true);
+        $this->setSuperUserAccess('zola', true);
 
         $ldapAuth = LdapAuth::makeConfigured();
         $ldapAuth->setLogin('zola');

--- a/tests/Integration/LdapIntegrationTest.php
+++ b/tests/Integration/LdapIntegrationTest.php
@@ -16,6 +16,7 @@ use Piwik\Db;
 use Piwik\Config;
 use Piwik\Plugins\LoginLdap\Ldap\LdapFunctions;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
+use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -90,7 +91,8 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
     protected function addPreexistingSuperUser()
     {
         UsersManagerAPI::getInstance()->addUser(self::TEST_SUPERUSER_LOGIN, self::TEST_SUPERUSER_PASS, 'srodgers@aol.com', $alias = false);
-        UsersManagerAPI::getInstance()->setSuperUserAccess(self::TEST_SUPERUSER_LOGIN, true);
+        $userUpdater = new UserUpdater();
+        $userUpdater->setSuperUserAccessWithoutCurrentPassword(self::TEST_SUPERUSER_LOGIN, true);
 
         $auth = StaticContainer::get('Piwik\Auth');
         $auth->setLogin(self::TEST_SUPERUSER_LOGIN);
@@ -102,7 +104,8 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
     protected function addNonLdapUsers()
     {
         UsersManagerAPI::getInstance()->addUser(self::NON_LDAP_USER, self::NON_LDAP_PASS, 'whatever@aol.com', $alias = false);
-        UsersManagerAPI::getInstance()->setSuperUserAccess(self::NON_LDAP_USER, true);
+        $userUpdater = new UserUpdater();
+        $userUpdater->setSuperUserAccessWithoutCurrentPassword(self::NON_LDAP_USER, true);
         UsersManagerAPI::getInstance()->addUser(self::NON_LDAP_NORMAL_USER, self::NON_LDAP_NORMAL_PASS, 'witchy@sdhs.edu', $alias = false);
     }
 

--- a/tests/Integration/LdapIntegrationTest.php
+++ b/tests/Integration/LdapIntegrationTest.php
@@ -91,8 +91,7 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
     protected function addPreexistingSuperUser()
     {
         UsersManagerAPI::getInstance()->addUser(self::TEST_SUPERUSER_LOGIN, self::TEST_SUPERUSER_PASS, 'srodgers@aol.com', $alias = false);
-        $userUpdater = new UserUpdater();
-        $userUpdater->setSuperUserAccessWithoutCurrentPassword(self::TEST_SUPERUSER_LOGIN, true);
+        $this->setSuperUserAccess(self::TEST_SUPERUSER_LOGIN, true);
 
         $auth = StaticContainer::get('Piwik\Auth');
         $auth->setLogin(self::TEST_SUPERUSER_LOGIN);
@@ -104,8 +103,7 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
     protected function addNonLdapUsers()
     {
         UsersManagerAPI::getInstance()->addUser(self::NON_LDAP_USER, self::NON_LDAP_PASS, 'whatever@aol.com', $alias = false);
-        $userUpdater = new UserUpdater();
-        $userUpdater->setSuperUserAccessWithoutCurrentPassword(self::NON_LDAP_USER, true);
+        $this->setSuperUserAccess(self::NON_LDAP_USER, true);
         UsersManagerAPI::getInstance()->addUser(self::NON_LDAP_NORMAL_USER, self::NON_LDAP_NORMAL_PASS, 'witchy@sdhs.edu', $alias = false);
     }
 
@@ -162,5 +160,15 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
         return array(
             'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger'),
         );
+    }
+
+    private function setSuperUserAccess($user, $hasAccess)
+    {
+        $userUpdater = new UserUpdater();
+        if (method_exists($userUpdater, 'setSuperUserAccessWithoutCurrentPassword')) {
+            $userUpdater->setSuperUserAccessWithoutCurrentPassword($user, $hasAccess);
+        } else {
+            UsersManagerAPI::getInstance()->setSuperUserAccess($user, $hasAccess);
+        }
     }
 }

--- a/tests/Integration/LdapIntegrationTest.php
+++ b/tests/Integration/LdapIntegrationTest.php
@@ -162,7 +162,7 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
         );
     }
 
-    private function setSuperUserAccess($user, $hasAccess)
+    protected function setSuperUserAccess($user, $hasAccess)
     {
         $userUpdater = new UserUpdater();
         if (method_exists($userUpdater, 'setSuperUserAccessWithoutCurrentPassword')) {

--- a/tests/System/SystemAuthTest.php
+++ b/tests/System/SystemAuthTest.php
@@ -17,6 +17,7 @@ use Piwik\Plugins\LoginLdap\Auth\LdapAuth;
 use Piwik\Plugins\LoginLdap\Auth\SynchronizedAuth;
 use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
 use Piwik\Plugins\LoginLdap\tests\Integration\LdapIntegrationTest;
+use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestingEnvironmentVariables;
 
@@ -167,7 +168,8 @@ class SystemAuthTest extends LdapIntegrationTest
 
         $this->assertNotEquals(AuthResult::FAILURE, $result->getCode());
 
-        \Piwik\Plugins\UsersManager\API::getInstance()->setSuperUserAccess(self::TEST_SUPERUSER_LOGIN, true);
+        $userUpdater = new UserUpdater();
+        $userUpdater->setSuperUserAccessWithoutCurrentPassword(self::TEST_SUPERUSER_LOGIN, true);
     }
 
     /**

--- a/tests/System/SystemAuthTest.php
+++ b/tests/System/SystemAuthTest.php
@@ -168,8 +168,7 @@ class SystemAuthTest extends LdapIntegrationTest
 
         $this->assertNotEquals(AuthResult::FAILURE, $result->getCode());
 
-        $userUpdater = new UserUpdater();
-        $userUpdater->setSuperUserAccessWithoutCurrentPassword(self::TEST_SUPERUSER_LOGIN, true);
+        $this->setSuperUserAccess((self::TEST_SUPERUSER_LOGIN, true);
     }
 
     /**

--- a/tests/System/SystemAuthTest.php
+++ b/tests/System/SystemAuthTest.php
@@ -168,7 +168,7 @@ class SystemAuthTest extends LdapIntegrationTest
 
         $this->assertNotEquals(AuthResult::FAILURE, $result->getCode());
 
-        $this->setSuperUserAccess((self::TEST_SUPERUSER_LOGIN, true);
+        $this->setSuperUserAccess(self::TEST_SUPERUSER_LOGIN, true);
     }
 
     /**

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -17,6 +17,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UserAccessFilter;
+use Piwik\Plugins\UsersManager\UserUpdater;
 
 /**
  * @group LoginLdap
@@ -171,20 +172,20 @@ class UserSynchronizerTest extends PHPUnit_Framework_TestCase
             });
         }
 
-        $mock->expects($this->any())->method('setSuperUserAccess')->willReturnCallback(function ($login, $hasSuperUserAccess) use ($self) {
-            $self->superUserAccess[] = array($login, $hasSuperUserAccess);
-        });
-
         $this->userSynchronizer->setUsersManagerApi($mock);
 
         $mock = $this->getMockBuilder('Piwik\Plugins\UsersManager\UserUpdater')
-            ->setMethods(array('updateUserWithoutCurrentPassword'))
+            ->setMethods(array('updateUserWithoutCurrentPassword', 'setSuperUserAccessWithoutCurrentPassword'))
             ->getMock();
         if ($throwsOnUpdateUser) {
             $mock->expects($this->any())->method('updateUserWithoutCurrentPassword')->willThrowException(new Exception("dummy message"));
         } else {
             $mock->expects($this->any())->method('updateUserWithoutCurrentPassword');
         }
+
+        $mock->expects($this->any())->method('setSuperUserAccessWithoutCurrentPassword')->willReturnCallback(function ($login, $hasSuperUserAccess) use ($self) {
+            $self->superUserAccess[] = array($login, $hasSuperUserAccess);
+        });
 
         $this->userSynchronizer->setUserUpdater($mock);
 

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -172,6 +172,11 @@ class UserSynchronizerTest extends PHPUnit_Framework_TestCase
             });
         }
 
+        // for previous version
+        $mock->expects($this->any())->method('setSuperUserAccess')->willReturnCallback(function ($login, $hasSuperUserAccess) use ($self) {
+            $self->superUserAccess[] = array($login, $hasSuperUserAccess);
+        });
+
         $this->userSynchronizer->setUsersManagerApi($mock);
 
         $mock = $this->getMockBuilder('Piwik\Plugins\UsersManager\UserUpdater')


### PR DESCRIPTION
For https://github.com/matomo-org/matomo/pull/13975 to avoid breaking the plugin.