### PR TITLE
add config option for stripping comain off web server auth

### DIFF
--- a/Auth/WebServerAuth.php
+++ b/Auth/WebServerAuth.php
@@ -65,7 +65,11 @@ class WebServerAuth extends Base
 
                 return $this->tryFallbackAuth($onlySuperUsers = false, $this->fallbackAuth);
             } else {
-                $this->login = preg_replace('/@.*/', '', $webServerAuthUser);
+                if (Config::getStripDomainFromWebAuth()) {
+                    $this->login = preg_replace('/@.*/', '', $webServerAuthUser);
+                } else {
+                    $this->login = $webServerAuthUser;
+                }
                 $this->password = '';
 
                 $this->logger->info("User '{login}' authenticated by webserver.", array('login' => $this->login));

--- a/Config.php
+++ b/Config.php
@@ -189,7 +189,7 @@ class Config
 
     public static function getStripDomainFromWebAuth()
     {
-        return self::getConfigOption('strip_domain_from_web_auth');
+        return self::getConfigOption('strip_domain_from_web_auth') == 1;
     }
 
     public static function getServerConfig($server)

--- a/Config.php
+++ b/Config.php
@@ -35,6 +35,7 @@ class Config
         'ldap_view_access_field' => 'view',
         'ldap_admin_access_field' => 'admin',
         'ldap_superuser_access_field' => 'superuser',
+        'strip_domain_from_web_auth' => 1,
         'use_webserver_auth' => 0,
         'user_access_attribute_server_specification_delimiter' => ';',
         'user_access_attribute_server_separator' => ':',
@@ -184,6 +185,11 @@ class Config
     public static function shouldAppendUserEmailSuffixToUsername()
     {
         return self::getConfigOption('append_user_email_suffix_to_username') == 1;
+    }
+
+    public static function getStripDomainFromWebAuth()
+    {
+        return self::getConfigOption('strip_domain_from_web_auth');
     }
 
     public static function getServerConfig($server)

--- a/lang/en.json
+++ b/lang/en.json
@@ -29,6 +29,8 @@
         "FilterDescription": "An LDAP filter used to determine which entities are allowed to be used for authentication, e.g. \"(objectClass=person)\".",
         "Kerberos": "Use Web Server Auth (e.g. Kerberos SSO)",
         "KerberosDescription": "If enabled, the plugin will check the $_SERVER['REMOTE_USER'] variable and assume the user is already authenticated. If the $_SERVER['REMOTE_USER'] is not present, all users are authenticated according to the other settings.",
+        "StripDomainFromWebAuth": "Strip Domain from Web Server Auth User",
+        "StripDomainFromWebAuthDescription": "If enabled, the domain part of the user in the $_SERVER['REMOTE_USER'] variable will be stripped away (i.e. anything after and including the first '@').",
         "LdapUserAdded": "LDAP user added successfully!",
         "LdapFunctionsMissing": "The PHP LDAP extension does not appear to be enabled. It is required for this plugin, please install it.",
         "CannotConnectToServer": "Could not connect to the LDAP server.",

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -38,6 +38,15 @@
                  inline-help="{{ 'LoginLdap_KerberosDescription'|translate|e('html_attr') }}">
             </div>
 
+            <div ng-show="ajaxForm.data.use_webserver_auth">
+                <div piwik-field uicontrol="checkbox" name="strip_domain_from_web_auth"
+                     title="{{ 'LoginLdap_StripDomainFromWebAuth'|translate|e('html_attr') }}"
+                     value="{{ ldapConfig.strip_domain_from_web_auth }}"
+                     ng-model="ajaxForm.data.strip_domain_from_web_auth"
+                     inline-help="{{ 'LoginLdap_StripDomainFromWebAuthDescription'|translate|e('html_attr') }}">
+                </div>
+            </div>
+
             <div piwik-field uicontrol="text" name="ldap_network_timeout"
                  title="{{ 'LoginLdap_NetworkTimeout'|translate|e('html_attr') }}"
                  value="{{ ldapConfig.ldap_network_timeout }}"

--- a/tests/Integration/WebServerAuthTest.php
+++ b/tests/Integration/WebServerAuthTest.php
@@ -146,4 +146,21 @@ class WebServerAuthTest extends LdapIntegrationTest
 
         $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $authResult->getCode());
     }
+
+    public function test_WebServerAuth_Fails_IfDomainNotStrippedCorrectly()
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        Config::getInstance()->LoginLdap['strip_domain_from_web_auth'] = 1;
+        $_SERVER['REMOTE_USER'] = self::TEST_LOGIN . '@shield.org';
+        $ldapAuth = WebServerAuth::makeConfigured();
+        $authResult = $ldapAuth->authenticate();
+        $this->assertEquals(AuthResult::SUCCESS, $authResult->getCode());
+
+        Config::getInstance()->LoginLdap['strip_domain_from_web_auth'] = 0;
+        $_SERVER['REMOTE_USER'] = self::TEST_LOGIN . '@shield.org';
+        $ldapAuth = WebServerAuth::makeConfigured();
+        $authResult = $ldapAuth->authenticate();
+        $this->assertEquals(AuthResult::FAILURE, $authResult->getCode());
+    }
 }


### PR DESCRIPTION
This is my attempt at fixing this, it works in our installation.
Default is to keep previous behavior.

Fixes matomo-org/plugin-LoginLdap#223