### PR TITLE
Fix some PHP8.1 deprecation warnings occurred while running tests

### DIFF
--- a/LdapInterop/UserAccessAttributeParser.php
+++ b/LdapInterop/UserAccessAttributeParser.php
@@ -143,7 +143,7 @@ class UserAccessAttributeParser
      */
     public function getSuperUserAccessFromSuperUserAttribute($attributeValue)
     {
-        $attributeValue = trim($attributeValue);
+        $attributeValue = trim($attributeValue ?? '');
 
         if ($attributeValue == 1
             || strtolower($attributeValue) == 'true'
@@ -232,7 +232,7 @@ class UserAccessAttributeParser
         $parts = explode($this->serverIdsSeparator, $spec);
 
         if (count($parts) == 1) { // there is no instanceId
-            $parts = array(null, $parts[0]);
+            return array(null, trim($parts[0]));
         } else if (count($parts) >= 2) { // malformed server access specification
             $this->logger->debug("UserAccessAttributeParser::{func}: Improper server specification in LDAP access attribute: '{value}'",
                 array('func' => __FUNCTION__, 'value' => $spec));
@@ -359,8 +359,8 @@ class UserAccessAttributeParser
             $parsed['port'] = 80;
         }
 
-        if (substr(@$parsed['path'], -1) !== '/') {
-            $parsed['path'] = @$parsed['path'] . '/';
+        if (!isset($parsed['path']) || substr(@$parsed['path'], -1) !== '/') {
+            $parsed['path'] = ($parsed['path'] ?? '') . '/';
         }
 
         return $parsed['host'] . ':' . $parsed['port'] . $parsed['path'];

--- a/LdapInterop/UserAccessAttributeParser.php
+++ b/LdapInterop/UserAccessAttributeParser.php
@@ -359,7 +359,7 @@ class UserAccessAttributeParser
             $parsed['port'] = 80;
         }
 
-        if (!isset($parsed['path']) || substr(@$parsed['path'], -1) !== '/') {
+        if (!isset($parsed['path']) || substr($parsed['path'], -1) !== '/') {
             $parsed['path'] = ($parsed['path'] ?? '') . '/';
         }
 

--- a/Model/LdapUsers.php
+++ b/Model/LdapUsers.php
@@ -138,7 +138,7 @@ class LdapUsers
     {
         $this->logger->debug(self::FUNCTION_START_LOG_MESSAGE, array(
             'function' => __FUNCTION__,
-            'params' => array($username, "<password[length=" . strlen($password) . "]>", $alreadyAuthenticated)
+            'params' => array($username, "<password[length=" . strlen($password ?? '') . "]>", $alreadyAuthenticated)
         ));
 
         if (empty($username)) {


### PR DESCRIPTION
### Description:



### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
