### PR TITLE
Changes to ensure new user is added during sync without password confirmation

### DIFF
--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -99,6 +99,11 @@ class UserSynchronizer
      */
     private $logger;
 
+    /**
+     * @var bool
+     */
+    public static $skipPasswordConfirmation = false;
+
     public function __construct(LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
@@ -135,7 +140,10 @@ class UserSynchronizer
             ));
 
             if (empty($existingUser)) {
+                //Need to set this to ensure we can add a new user without any password confirmation, refer skipPasswordConfirmation() in LoginLdap.php for further usage
+                self::$skipPasswordConfirmation = true;
                 $usersManagerApi->addUser($user['login'], $user['password'], $user['email'], $isPasswordHashed = true);
+                self::$skipPasswordConfirmation = false;
 
                 // set new user view access
                 if (!empty($newUserDefaultSitesWithViewAccess)) {

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -16,6 +16,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\LoginLdap\Auth\Base as AuthBase;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
+use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\View;
 
 /**
@@ -40,6 +41,7 @@ class LoginLdap extends \Piwik\Plugin
             'Controller.LoginLdap.resetPassword'     => 'disablePasswordResetForLdapUsers',
             'Controller.Login.confirmResetPassword'  => 'disableConfirmResetPasswordForLdapUsers',
             'UsersManager.checkPassword'             => 'checkPassword',
+            'Login.userRequiresPasswordConfirmation' => 'skipPasswordConfirmation',
         );
         return $hooks;
     }
@@ -267,5 +269,18 @@ class LoginLdap extends \Piwik\Plugin
     {
         $auth = StaticContainer::get('Piwik\Auth');
         $this->disablePasswordChangeForLdapUsers($auth);
+    }
+
+    /**
+     * @param $requiresPasswordConfirmation
+     * @param $login
+     *
+     * Skip password confirmation if its being added by LDAP sync
+     */
+    public function skipPasswordConfirmation(&$requiresPasswordConfirmation, $login)
+    {
+        if (UserSynchronizer::$skipPasswordConfirmation) {
+            $requiresPasswordConfirmation = false;
+        }
     }
 }


### PR DESCRIPTION
### Description:

Changes to ensure new user is added during sync without password confirmation.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
