### PR TITLE
Allow single quote character in admin password

### DIFF
--- a/Ldap/ServerInfo.php
+++ b/Ldap/ServerInfo.php
@@ -78,7 +78,7 @@ class ServerInfo
         $this->baseDn = $baseDn;
         $this->serverPort = $serverPort;
         $this->adminUsername = $adminUsername;
-        $this->adminPassword = $adminPassword;
+        $this->setAdminPassword($adminPassword);
         $this->startTLS = $startTLS;
     }
 
@@ -187,7 +187,7 @@ class ServerInfo
      * @param string $adminPassword
      */
     public function setAdminPassword($adminPassword) {
-        $this->adminPassword = stripcslashes($adminPassword);
+        $this->adminPassword = !empty($adminPassword) ? stripcslashes($adminPassword) : $adminPassword;
     }
 
     /**

--- a/Ldap/ServerInfo.php
+++ b/Ldap/ServerInfo.php
@@ -187,7 +187,7 @@ class ServerInfo
      * @param string $adminPassword
      */
     public function setAdminPassword($adminPassword) {
-        $this->adminPassword = $adminPassword;
+        $this->adminPassword = stripcslashes($adminPassword);
     }
 
     /**

--- a/tests/Unit/ServerInfoTest.php
+++ b/tests/Unit/ServerInfoTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugins\LoginLdap\Ldap\ServerInfo;
+
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_ServerInfoTest
+ */
+class ServerInfoTest extends TestCase
+{
+    const TEST_HOST_NAME = 'some-host.com';
+    const TEST_ADMIN_USER = 'who?';
+    const TEST_ADMIN_PASS = 'pass123!';
+    const TEST_BASE_DN = 'testbasedn';
+
+    public function testConstruct()
+    {
+        $serverInfo = new ServerInfo(
+            self::TEST_HOST_NAME,
+            self::TEST_BASE_DN,
+            ServerInfo::DEFAULT_LDAP_PORT,
+            self::TEST_ADMIN_USER,
+            self::TEST_ADMIN_PASS
+        );
+
+        $this->assertSame(self::TEST_HOST_NAME, $serverInfo->getServerHostname());
+        $this->assertSame(self::TEST_BASE_DN, $serverInfo->getBaseDn());
+        $this->assertSame(ServerInfo::DEFAULT_LDAP_PORT, $serverInfo->getServerPort());
+        $this->assertSame(self::TEST_ADMIN_USER, $serverInfo->getAdminUsername());
+        $this->assertSame(self::TEST_ADMIN_PASS, $serverInfo->getAdminPassword());
+    }
+
+    public function testConstructWithQuoteInPassword()
+    {
+        $serverInfo = new ServerInfo(
+            self::TEST_HOST_NAME,
+            self::TEST_BASE_DN,
+            ServerInfo::DEFAULT_LDAP_PORT,
+            self::TEST_ADMIN_USER,
+            "some\'pass"
+        );
+
+        $this->assertSame(self::TEST_HOST_NAME, $serverInfo->getServerHostname());
+        $this->assertSame(self::TEST_BASE_DN, $serverInfo->getBaseDn());
+        $this->assertSame(ServerInfo::DEFAULT_LDAP_PORT, $serverInfo->getServerPort());
+        $this->assertSame(self::TEST_ADMIN_USER, $serverInfo->getAdminUsername());
+        $this->assertSame("some'pass", $serverInfo->getAdminPassword());
+    }
+
+    public function testSetAdminPassword()
+    {
+        $serverInfo = new ServerInfo(self::TEST_HOST_NAME, self::TEST_BASE_DN);
+        $this->assertEmpty($serverInfo->getAdminPassword());
+        $serverInfo->setAdminPassword(self::TEST_ADMIN_PASS);
+        $this->assertSame(self::TEST_ADMIN_PASS, $serverInfo->getAdminPassword());
+    }
+
+    public function testSetAdminPasswordWithQuoteInPassword()
+    {
+        $serverInfo = new ServerInfo(self::TEST_HOST_NAME, self::TEST_BASE_DN);
+        $this->assertEmpty($serverInfo->getAdminPassword());
+        $serverInfo->setAdminPassword("some\'pass");
+        $this->assertSame("some'pass", $serverInfo->getAdminPassword());
+    }
+}


### PR DESCRIPTION
### Description:

We should probably support the single quote character in the admin password. This change does that.
Fixes: #308 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
