### PR TITLE
Added return for command classes

### DIFF
--- a/Commands/SynchronizeUsers.php
+++ b/Commands/SynchronizeUsers.php
@@ -57,6 +57,12 @@ class SynchronizeUsers extends ConsoleCommand
             . "update user info if it has changed in LDAP.");
     }
 
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $logins = $input->getOption('login');
@@ -99,9 +105,11 @@ class SynchronizeUsers extends ConsoleCommand
             foreach ($failed as $missingLogin) {
                 $output->writeln($missingLogin['login'] . "\t\t<comment>{$missingLogin['reason']}</comment>");
             }
+
+            return self::FAILURE;
         }
 
-        return count($failed);
+        return self::SUCCESS;
     }
 
     private function userExistsInPiwik($login)


### PR DESCRIPTION
### Description:

Added return for command classes.
Fixes: #PG-2642

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
