### PR TITLE
Fixed _isLDAPUser option not being deleted from option table on user deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 4.7.2
+* Fixed _isLDAPUser option not being deleted from option table on user deletion.
+
 #### LoginLdap 4.7.1
 * Updated migration script to include only users synced in Matomo
 

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -12,12 +12,14 @@ use Piwik\Auth;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\FrontController;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\LoginLdap\Auth\Base as AuthBase;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\View;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 
 /**
  *
@@ -41,6 +43,7 @@ class LoginLdap extends \Piwik\Plugin
             'Controller.LoginLdap.resetPassword'     => 'disablePasswordResetForLdapUsers',
             'Controller.Login.confirmResetPassword'  => 'disableConfirmResetPasswordForLdapUsers',
             'UsersManager.checkPassword'             => 'checkPassword',
+            'UsersManager.deleteUser'                => 'onUserDeleted',
             'Login.userRequiresPasswordConfirmation' => 'skipPasswordConfirmation',
         );
         return $hooks;
@@ -283,6 +286,20 @@ class LoginLdap extends \Piwik\Plugin
     {
         if (UserSynchronizer::$skipPasswordConfirmation) {
             $requiresPasswordConfirmation = false;
+        }
+    }
+
+    /**
+     * @param $userLogin
+     *
+     * On User deleted hook
+     */
+    public function onUserDeleted($userLogin)
+    {
+        //if we do not delete this option value, it creates a problem in syncing the same user as checkPassword is executed and $this->>disablePasswordChangeForLdapUsers throws an exception, since it determines it as an LDAP user
+        if ($this->isUserLdapUser($userLogin)) {
+            $key = $userLogin . UsersManagerAPI::OPTION_NAME_PREFERENCE_SEPARATOR . UserMapper::USER_PREFERENCE_NAME_IS_LDAP_USER;
+            Option::delete($key);
         }
     }
 }

--- a/Updates/4.7.2.php
+++ b/Updates/4.7.2.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginLdap;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Option;
+use Piwik\Updater;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+use Piwik\Updates;
+use Piwik\Plugins\UsersManager\Model as UsersModel;
+use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
+
+/**
+ */
+class Updates_4_7_2 extends Updates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+
+        $userModel = new UsersModel();
+        $logins = $userModel->getUsers([]);
+
+        $loginNames = [];
+
+        $optionTable = Common::prefixTable('option');
+
+        $searchPattern = UsersManagerAPI::OPTION_NAME_PREFERENCE_SEPARATOR . UserMapper::USER_PREFERENCE_NAME_IS_LDAP_USER;
+        $db = Db::get();
+        $optionValues = $db->fetchAll("Select option_name from $optionTable where option_name like '%$searchPattern'");
+        foreach ($logins as $login) {
+            $loginNames[$login['login']] = 1;
+        }
+
+        foreach ($optionValues as $optionValue) {
+            $userLogin = str_replace($searchPattern, '', $optionValue['option_name']);
+            if (!isset($loginNames[$userLogin])) {
+                $key = $userLogin . $searchPattern;
+                Option::delete($key);
+            }
+        }
+    }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "4.7.1",
+    "version": "4.7.2",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],


### PR DESCRIPTION
### Description:

Fixed _isLDAPUser option not being deleted from option table on user deletion.
Fixes: #332 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
