### PR TITLE
Log only when archiving process is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.0.4
+* Fixed archiving error due to logs being printed for non-archive requests
+
 #### LoginLdap 5.0.3
 * Added code to auto accept invitation if present
 

--- a/LdapInterop/UserAccessAttributeParser.php
+++ b/LdapInterop/UserAccessAttributeParser.php
@@ -8,6 +8,7 @@
 namespace Piwik\Plugins\LoginLdap\LdapInterop;
 
 use Piwik\Access;
+use Piwik\ArchiveProcessor\PluginsArchiver;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\LoginLdap\Config;
 use Piwik\Site;
@@ -388,7 +389,7 @@ class UserAccessAttributeParser
         if (!empty($thisPiwikInstanceName)) {
             $result->setThisPiwikInstanceName($thisPiwikInstanceName);
         } else {
-            if ($result->getServerIdsSeparator() == ':') {
+            if ($result->getServerIdsSeparator() == ':' && PluginsArchiver::isArchivingProcessActive()) {
                 // TODO: remove this warning and move it to the settings page.
                 /** @var LoggerInterface $logger */
                 $logger = StaticContainer::get(LoggerInterface::class);

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],


### PR DESCRIPTION
### Description:

Log only when archiving process is active.
Fixes: #357

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
