### PR TITLE
[PHP 8.4] Explicitly mark nullable typed parameters

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -98,7 +98,7 @@ abstract class Base implements Auth
      */
     protected $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }
@@ -290,7 +290,7 @@ abstract class Base implements Auth
         return $this->userForLogin;
     }
 
-    protected function tryFallbackAuth($onlySuperUsers = true, Auth $auth = null)
+    protected function tryFallbackAuth($onlySuperUsers = true, ?Auth $auth = null)
     {
         if (empty($auth)) {
             $auth = new \Piwik\Plugins\Login\Auth();

--- a/LdapInterop/UserAccessAttributeParser.php
+++ b/LdapInterop/UserAccessAttributeParser.php
@@ -110,7 +110,7 @@ class UserAccessAttributeParser
      */
     private $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }

--- a/LdapInterop/UserAccessMapper.php
+++ b/LdapInterop/UserAccessMapper.php
@@ -85,7 +85,7 @@ class UserAccessMapper
     /**
      * Constructor.
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }

--- a/LdapInterop/UserMapper.php
+++ b/LdapInterop/UserMapper.php
@@ -76,7 +76,7 @@ class UserMapper
     /**
      * Constructor.
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -108,7 +108,7 @@ class UserSynchronizer
      */
     public static $skipPasswordConfirmation = false;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }

--- a/Model/LdapUsers.php
+++ b/Model/LdapUsers.php
@@ -119,7 +119,7 @@ class LdapUsers
     /**
      * Constructor.
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }


### PR DESCRIPTION
### Description:

With PHP 8.4 implicitly type hinting nullable parameters is deprecated. Therefor we need to explicitly mark them as nullable.

@AltamashShaikh @snake14 You might need to check all the other plugins as well at some point to improve PHP 8.4 compatibility.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
