### PR TITLE
Adjust default port for ldaps protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.1.1 - 2025-03-17
+* Adjust default port for ldaps protocol
+
 #### LoginLdap 5.1.0 - 2025-03-03
 * Corrects compatibility issue with Login plugin
 

--- a/Ldap/ServerInfo.php
+++ b/Ldap/ServerInfo.php
@@ -18,6 +18,7 @@ use Piwik\Plugins\LoginLdap\Config;
 class ServerInfo
 {
     public const DEFAULT_LDAP_PORT = 389;
+    public const DEFAULT_LDAPS_PORT = 636;
 
     /**
      * The LDAP server hostname.
@@ -76,14 +77,16 @@ class ServerInfo
     public function __construct(
         $serverHostname,
         $baseDn,
-        $serverPort = self::DEFAULT_LDAP_PORT,
+        $serverPort = 0,
         $adminUsername = null,
         $adminPassword = null,
         $startTLS = null
     ) {
+        // Check if the default port should be different due to protocol in the host name
+        $defaultPort = stripos($serverHostname, 'ldaps:') === 0 ? ServerInfo::DEFAULT_LDAPS_PORT : ServerInfo::DEFAULT_LDAP_PORT;
         $this->serverHostname = $serverHostname;
         $this->baseDn = $baseDn;
-        $this->serverPort = $serverPort;
+        $this->serverPort = $serverPort ?: $defaultPort;
         $this->adminUsername = $adminUsername;
         $this->setAdminPassword($adminPassword);
         $this->startTLS = $startTLS;

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/tests/Unit/ServerInfoTest.php
+++ b/tests/Unit/ServerInfoTest.php
@@ -42,6 +42,60 @@ class ServerInfoTest extends TestCase
         $this->assertSame(self::TEST_ADMIN_PASS, $serverInfo->getAdminPassword());
     }
 
+    public function testConstructNoPort()
+    {
+        $serverInfo = new ServerInfo(
+            self::TEST_HOST_NAME,
+            self::TEST_BASE_DN
+        );
+
+        $this->assertSame(self::TEST_HOST_NAME, $serverInfo->getServerHostname());
+        $this->assertSame(self::TEST_BASE_DN, $serverInfo->getBaseDn());
+        $this->assertSame(ServerInfo::DEFAULT_LDAP_PORT, $serverInfo->getServerPort());
+    }
+
+    public function testConstructNoPortLdaps()
+    {
+        $ldapsHostName = 'ldaps://' . self::TEST_HOST_NAME;
+        $serverInfo = new ServerInfo(
+            $ldapsHostName,
+            self::TEST_BASE_DN
+        );
+
+        $this->assertSame($ldapsHostName, $serverInfo->getServerHostname());
+        $this->assertSame(self::TEST_BASE_DN, $serverInfo->getBaseDn());
+        $this->assertSame(ServerInfo::DEFAULT_LDAPS_PORT, $serverInfo->getServerPort());
+    }
+
+    public function testConstructSpecificPort()
+    {
+        $port = 1234;
+        $serverInfo = new ServerInfo(
+            self::TEST_HOST_NAME,
+            self::TEST_BASE_DN,
+            $port
+        );
+
+        $this->assertSame(self::TEST_HOST_NAME, $serverInfo->getServerHostname());
+        $this->assertSame(self::TEST_BASE_DN, $serverInfo->getBaseDn());
+        $this->assertSame($port, $serverInfo->getServerPort());
+    }
+
+    public function testConstructSpecificPortLdaps()
+    {
+        $ldapsHostName = 'ldaps://' . self::TEST_HOST_NAME;
+        $port = 1234;
+        $serverInfo = new ServerInfo(
+            $ldapsHostName,
+            self::TEST_BASE_DN,
+            $port
+        );
+
+        $this->assertSame($ldapsHostName, $serverInfo->getServerHostname());
+        $this->assertSame(self::TEST_BASE_DN, $serverInfo->getBaseDn());
+        $this->assertSame($port, $serverInfo->getServerPort());
+    }
+
     public function testConstructWithQuoteInPassword()
     {
         $serverInfo = new ServerInfo(


### PR DESCRIPTION
### Description:

It was noticed that using PHP 8.3 or higher resulted in the plugin using the wrong default port for hosts using `ldaps://`. This PR corrects that behaviour.
Fixes: #397 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
