### PR TITLE
Adds code to delete all the access if no access returned from Ldap and enable_synchronize_access_from_ldap=1, #PG-4868

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LoginLdap Changelog
 
-#### LoginLdap 5.1.4 - 2025-01-19
+#### LoginLdap 5.1.4 - 2025-01-12
 * Added code to delete all the access if no access returned from Ldap and enable_synchronize_access_from_ldap=1
 
 #### LoginLdap 5.1.3 - 2025-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.1.4 - 2025-01-19
+* Added code to delete all the access if no access returned from Ldap and enable_synchronize_access_from_ldap=1
+
 #### LoginLdap 5.1.3 - 2025-07-07
 * Textual changes
 

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -201,18 +201,20 @@ class UserSynchronizer
         $this->userModel->setSuperUserAccess($piwikLogin, false);
 
         $usersManagerApi = $this->usersManagerApi;
-        foreach ($userAccess as $userAccessLevel => $sites) {
-            Access::doAsSuperUser(function () use ($usersManagerApi, $userAccessLevel, $sites, $piwikLogin) {
-                if ($userAccessLevel == 'superuser') {
-                    if (method_exists('Piwik\Plugins\UsersManager\UserUpdater', 'setSuperUserAccessWithoutCurrentPassword')) {
-                        $this->userUpdater->setSuperUserAccessWithoutCurrentPassword($piwikLogin, true);
+        if (!empty($userAccess)) {
+            foreach ($userAccess as $userAccessLevel => $sites) {
+                Access::doAsSuperUser(function () use ($usersManagerApi, $userAccessLevel, $sites, $piwikLogin) {
+                    if ($userAccessLevel == 'superuser') {
+                        if (method_exists('Piwik\Plugins\UsersManager\UserUpdater', 'setSuperUserAccessWithoutCurrentPassword')) {
+                            $this->userUpdater->setSuperUserAccessWithoutCurrentPassword($piwikLogin, true);
+                        } else {
+                            $usersManagerApi->setSuperUserAccess($piwikLogin, true);
+                        }
                     } else {
-                        $usersManagerApi->setSuperUserAccess($piwikLogin, true);
+                        $usersManagerApi->setUserAccess($piwikLogin, $userAccessLevel, $sites);
                     }
-                } else {
-                    $usersManagerApi->setUserAccess($piwikLogin, $userAccessLevel, $sites);
-                }
-            });
+                });
+            }
         }
     }
 

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -21,7 +21,6 @@ use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Site;
 use Piwik\Log\LoggerInterface;
-use Piwik\Tracker\Cache;
 
 /**
  * Synchronizes LDAP user information with the Piwik database.
@@ -189,25 +188,13 @@ class UserSynchronizer
      */
     public function synchronizePiwikAccessFromLdap($piwikLogin, $ldapUser)
     {
-        if (empty($this->userAccessMapper)) {
+        // UserSynchronizer::makeConfigured() only sets a UserAccessMapper when Config::isAccessSynchronizationEnabled()
+        // is true, so return early in this case.
+        if (empty($this->userAccessMapper) || !Config::isAccessSynchronizationEnabled()) {
             return;
         }
 
         $userAccess = $this->userAccessMapper->getPiwikUserAccessForLdapUser($ldapUser);
-        if (empty($userAccess)) {
-            if (Config::isAccessSynchronizationEnabled()) {
-                $this->logger->log('warning', "UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", array(
-                    'func' => __FUNCTION__,
-                    'user' => $piwikLogin
-                ));
-                // Delete the access if isAccessSynchronizationEnabled and no userAccess is mapped
-                $this->userModel->deleteUserAccess($piwikLogin);
-                $this->userModel->setSuperUserAccess($piwikLogin, false);
-                Cache::deleteTrackerCache();
-            }
-
-            return;
-        }
 
         // for the synchronization, need to reset all user accesses
         $this->userModel->deleteUserAccess($piwikLogin);

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -189,24 +189,20 @@ class UserSynchronizer
      */
     public function synchronizePiwikAccessFromLdap($piwikLogin, $ldapUser)
     {
-        if (empty($this->userAccessMapper)) {
+        if (empty($this->userAccessMapper) || !Config::isAccessSynchronizationEnabled()) {
             return;
         }
 
         $userAccess = $this->userAccessMapper->getPiwikUserAccessForLdapUser($ldapUser);
         if (empty($userAccess)) {
-            if (Config::isAccessSynchronizationEnabled()) {
-                // Delete the access if isAccessSynchronizationEnabled and no userAccess is mapped
-                $this->userModel->deleteUserAccess($piwikLogin);
-                $this->userModel->setSuperUserAccess($piwikLogin, false);
-                Cache::deleteTrackerCache();
-                $this->logger->log('warning', 'Deleting all the access since access synchronization is enabled, but no access mapped.');
-            } else {
-                $this->logger->log('warning', "UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled.", array(
-                    'func' => __FUNCTION__,
-                    'user' => $piwikLogin
-                ));
-            }
+            $this->logger->log('warning', "UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", array(
+                'func' => __FUNCTION__,
+                'user' => $piwikLogin
+            ));
+            // Delete the access if isAccessSynchronizationEnabled and no userAccess is mapped
+            $this->userModel->deleteUserAccess($piwikLogin);
+            $this->userModel->setSuperUserAccess($piwikLogin, false);
+            Cache::deleteTrackerCache();
 
             return;
         }

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -21,6 +21,7 @@ use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Site;
 use Piwik\Log\LoggerInterface;
+use Piwik\Tracker\Cache;
 
 /**
  * Synchronizes LDAP user information with the Piwik database.
@@ -194,10 +195,18 @@ class UserSynchronizer
 
         $userAccess = $this->userAccessMapper->getPiwikUserAccessForLdapUser($ldapUser);
         if (empty($userAccess)) {
-            $this->logger->warning("UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled.", array(
-                'func' => __FUNCTION__,
-                'user' => $piwikLogin
-            ));
+            if (Config::isAccessSynchronizationEnabled()) {
+                // Delete the access if isAccessSynchronizationEnabled and no userAccess is mapped
+                $this->userModel->deleteUserAccess($piwikLogin);
+                $this->userModel->setSuperUserAccess($piwikLogin, false);
+                Cache::deleteTrackerCache();
+                $this->logger->log('warning', 'Deleting all the access since access synchronization is enabled, but no access mapped.');
+            } else {
+                $this->logger->log('warning',"UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled.", array(
+                    'func' => __FUNCTION__,
+                    'user' => $piwikLogin
+                ));
+            }
 
             return;
         }

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -189,20 +189,22 @@ class UserSynchronizer
      */
     public function synchronizePiwikAccessFromLdap($piwikLogin, $ldapUser)
     {
-        if (empty($this->userAccessMapper) || !Config::isAccessSynchronizationEnabled()) {
+        if (empty($this->userAccessMapper)) {
             return;
         }
 
         $userAccess = $this->userAccessMapper->getPiwikUserAccessForLdapUser($ldapUser);
         if (empty($userAccess)) {
-            $this->logger->log('warning', "UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", array(
-                'func' => __FUNCTION__,
-                'user' => $piwikLogin
-            ));
-            // Delete the access if isAccessSynchronizationEnabled and no userAccess is mapped
-            $this->userModel->deleteUserAccess($piwikLogin);
-            $this->userModel->setSuperUserAccess($piwikLogin, false);
-            Cache::deleteTrackerCache();
+            if (Config::isAccessSynchronizationEnabled()) {
+                $this->logger->log('warning', "UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", array(
+                    'func' => __FUNCTION__,
+                    'user' => $piwikLogin
+                ));
+                // Delete the access if isAccessSynchronizationEnabled and no userAccess is mapped
+                $this->userModel->deleteUserAccess($piwikLogin);
+                $this->userModel->setSuperUserAccess($piwikLogin, false);
+                Cache::deleteTrackerCache();
+            }
 
             return;
         }

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -202,7 +202,7 @@ class UserSynchronizer
                 Cache::deleteTrackerCache();
                 $this->logger->log('warning', 'Deleting all the access since access synchronization is enabled, but no access mapped.');
             } else {
-                $this->logger->log('warning',"UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled.", array(
+                $this->logger->log('warning', "UserSynchronizer::{func}: User '{user}' has no access in LDAP, but access synchronization is enabled.", array(
                     'func' => __FUNCTION__,
                     'user' => $piwikLogin
                 ));

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.1.3",
+    "version": "5.1.4",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -164,7 +164,7 @@ class UserSynchronizerTest extends TestCase
 
         // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=0, it should do nothing
         $config = Config::getInstance()->LoginLdap;
-        $oldValue = $config['enable_synchronize_access_from_ldap'];
+        $oldValue = $config['enable_synchronize_access_from_ldap'] ?? 0;
         $config['enable_synchronize_access_from_ldap'] = 0;
         Config::getInstance()->LoginLdap = $config;
         $this->setUserAccessMapperMock([], $userSynchronizer);
@@ -200,7 +200,7 @@ class UserSynchronizerTest extends TestCase
 
         // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=1, it should delete access
         $config = Config::getInstance()->LoginLdap;
-        $oldValue = $config['enable_synchronize_access_from_ldap'];
+        $oldValue = $config['enable_synchronize_access_from_ldap'] ?? 0;
         $config['enable_synchronize_access_from_ldap'] = 1;
         Config::getInstance()->LoginLdap = $config;
         $this->setUserAccessMapperMock([], $userSynchronizer);

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -166,7 +166,7 @@ class UserSynchronizerTest extends TestCase
         $config = Config::getInstance()->LoginLdap;
         $config['enable_synchronize_access_from_ldap'] = 0;
         Config::getInstance()->LoginLdap = $config;
-        $this->setUserAccessMapperMock([],$userSynchronizer);
+        $this->setUserAccessMapperMock([], $userSynchronizer);
         $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
         $this->assertStringContainsString("UserSynchronizer::synchronizePiwikAccessFromLdap: User 'piwikuser' has no access in LDAP, but access synchronization is enabled.", $logger->output);
     }
@@ -199,7 +199,7 @@ class UserSynchronizerTest extends TestCase
         $config = Config::getInstance()->LoginLdap;
         $config['enable_synchronize_access_from_ldap'] = 1;
         Config::getInstance()->LoginLdap = $config;
-        $this->setUserAccessMapperMock([],$userSynchronizer);
+        $this->setUserAccessMapperMock([], $userSynchronizer);
         $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
         $this->assertStringContainsString("Deleting all the access since access synchronization is enabled, but no access mapped.", $logger->output);
     }

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -168,7 +168,7 @@ class UserSynchronizerTest extends TestCase
         Config::getInstance()->LoginLdap = $config;
         $this->setUserAccessMapperMock([], $userSynchronizer);
         $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
-        $this->assertStringContainsString("UserSynchronizer::synchronizePiwikAccessFromLdap: User 'piwikuser' has no access in LDAP, but access synchronization is enabled.", $logger->output);
+        $this->assertEmpty($logger->output);
     }
 
     public function test_synchronizePiwikAccessFromLdap_WillRemoveAccessWhenAccessEmptyAndSyncEnabled()
@@ -201,7 +201,7 @@ class UserSynchronizerTest extends TestCase
         Config::getInstance()->LoginLdap = $config;
         $this->setUserAccessMapperMock([], $userSynchronizer);
         $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
-        $this->assertStringContainsString("Deleting all the access since access synchronization is enabled, but no access mapped.", $logger->output);
+        $this->assertStringContainsString("UserSynchronizer::synchronizePiwikAccessFromLdap: User 'piwikuser' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", $logger->output);
     }
 
     public function test_synchronizePiwikAccessFromLdap_Succeeds_IfLdapUserHasNoAccess()

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -18,6 +18,7 @@ use Piwik\Config;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UserAccessFilter;
+use Piwik\Tests\Framework\Mock\FakeLogger;
 
 /**
  * @group LoginLdap
@@ -137,6 +138,72 @@ class UserSynchronizerTest extends TestCase
         ), $this->superUserAccess);
     }
 
+    public function test_synchronizePiwikAccessFromLdap_WillNotRemoveAccessWhenAccessEmptyButSyncDisabled()
+    {
+        $logger = new FakeLogger();
+        $userSynchronizer = new UserSynchronizer($logger);
+        $this->setUserModelMock($this->getPiwikUserData(), $userSynchronizer);
+        $this->setUserMapperMock($this->getPiwikUserData(), $userSynchronizer);
+        $this->setUserManagerApiMock($throwsOnAdd = false, false, false, $userSynchronizer);
+
+        // First iteration returns mapping
+        $this->setUserAccessMapperMock(array(
+            'superuser' => array(7,8,9),
+            'view' => array(1,2,3),
+            'admin' => array(4,5,6)
+        ), $userSynchronizer);
+        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        // Verify access mapping is present
+        $this->assertEquals(array(
+            array('piwikuser', 'view', array(1,2,3)),
+            array('piwikuser', 'admin', array(4,5,6))
+        ), $this->userAccess);
+        $this->assertEquals(array(
+            array('piwikuser', true)
+        ), $this->superUserAccess);
+
+        // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=0, it should do nothing
+        $config = Config::getInstance()->LoginLdap;
+        $config['enable_synchronize_access_from_ldap'] = 0;
+        Config::getInstance()->LoginLdap = $config;
+        $this->setUserAccessMapperMock([],$userSynchronizer);
+        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        $this->assertStringContainsString("UserSynchronizer::synchronizePiwikAccessFromLdap: User 'piwikuser' has no access in LDAP, but access synchronization is enabled.", $logger->output);
+    }
+
+    public function test_synchronizePiwikAccessFromLdap_WillRemoveAccessWhenAccessEmptyAndSyncEnabled()
+    {
+        $logger = new FakeLogger();
+        $userSynchronizer = new UserSynchronizer($logger);
+        $this->setUserModelMock($this->getPiwikUserData(), $userSynchronizer);
+        $this->setUserMapperMock($this->getPiwikUserData(), $userSynchronizer);
+        $this->setUserManagerApiMock($throwsOnAdd = false, false, false, $userSynchronizer);
+
+        // First iteration returns mapping
+        $this->setUserAccessMapperMock(array(
+            'superuser' => array(7,8,9),
+            'view' => array(1,2,3),
+            'admin' => array(4,5,6)
+        ), $userSynchronizer);
+        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        // Verify access mapping is present
+        $this->assertEquals(array(
+            array('piwikuser', 'view', array(1,2,3)),
+            array('piwikuser', 'admin', array(4,5,6))
+        ), $this->userAccess);
+        $this->assertEquals(array(
+            array('piwikuser', true)
+        ), $this->superUserAccess);
+
+        // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=1, it should delete access
+        $config = Config::getInstance()->LoginLdap;
+        $config['enable_synchronize_access_from_ldap'] = 1;
+        Config::getInstance()->LoginLdap = $config;
+        $this->setUserAccessMapperMock([],$userSynchronizer);
+        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        $this->assertStringContainsString("Deleting all the access since access synchronization is enabled, but no access mapped.", $logger->output);
+    }
+
     public function test_synchronizePiwikAccessFromLdap_Succeeds_IfLdapUserHasNoAccess()
     {
         $this->setUserManagerApiMock($throwsOnAdd = false);
@@ -147,7 +214,7 @@ class UserSynchronizerTest extends TestCase
         $this->assertEquals(array(), $this->superUserAccess);
     }
 
-    private function setUserManagerApiMock($throwsOnAddUser, $throwsOnUpdateUser = false, $throwsOnSetAccess = false)
+    private function setUserManagerApiMock($throwsOnAddUser, $throwsOnUpdateUser = false, $throwsOnSetAccess = false, &$userSynchronizer = null)
     {
         $self = $this;
         $model = new Model();
@@ -174,7 +241,11 @@ class UserSynchronizerTest extends TestCase
             $self->superUserAccess[] = array($login, $hasSuperUserAccess);
         });
 
-        $this->userSynchronizer->setUsersManagerApi($mock);
+        if ($userSynchronizer) {
+            $userSynchronizer->setUsersManagerApi($mock);
+        } else {
+            $this->userSynchronizer->setUsersManagerApi($mock);
+        }
 
         $mock = $this->getMockBuilder('Piwik\Plugins\UsersManager\UserUpdater')
             ->onlyMethods(array('updateUserWithoutCurrentPassword', 'setSuperUserAccessWithoutCurrentPassword'))
@@ -189,7 +260,11 @@ class UserSynchronizerTest extends TestCase
             $self->superUserAccess[] = array($login, $hasSuperUserAccess);
         });
 
-        $this->userSynchronizer->setUserUpdater($mock);
+        if ($userSynchronizer) {
+            $userSynchronizer->setUserUpdater($mock);
+        } else {
+            $this->userSynchronizer->setUserUpdater($mock);
+        }
     }
 
     private function getPiwikUserData()
@@ -201,7 +276,7 @@ class UserSynchronizerTest extends TestCase
         );
     }
 
-    private function setUserMapperMock($value, $throws = false)
+    private function setUserMapperMock($value, $throws = false, &$userSynchronizer = null)
     {
         $mock = $this->getMockBuilder('Piwik\Plugins\LoginLdap\LdapInterop\UserMapper')
                      ->onlyMethods(array('createPiwikUserFromLdapUser', 'markUserAsLdapUser'))
@@ -211,25 +286,37 @@ class UserSynchronizerTest extends TestCase
         } else {
             $mock->expects($this->any())->method('createPiwikUserFromLdapUser')->will($this->returnValue($value));
         }
-        $this->userSynchronizer->setUserMapper($mock);
+        if ($userSynchronizer) {
+            $userSynchronizer->setUserMapper($mock);
+        } else {
+            $this->userSynchronizer->setUserMapper($mock);
+        }
     }
 
-    private function setUserAccessMapperMock($value)
+    private function setUserAccessMapperMock($value, &$userSynchronizer = null)
     {
         $mock = $this->getMockBuilder('Piwik\Plugins\LoginLdap\LdapInterop\UserAccessMapper')
                      ->onlyMethods(array('getPiwikUserAccessForLdapUser'))
                      ->getMock();
         $mock->expects($this->any())->method('getPiwikUserAccessForLdapUser')->will($this->returnValue($value));
-        $this->userSynchronizer->setUserAccessMapper($mock);
+        if ($userSynchronizer) {
+            $userSynchronizer->setUserAccessMapper($mock);
+        } else {
+            $this->userSynchronizer->setUserAccessMapper($mock);
+        }
     }
 
-    private function setUserModelMock($returnValue)
+    private function setUserModelMock($returnValue, &$userSynchronizer = null)
     {
         $mock = $this->getMockBuilder('Piwik\Plugins\UsersManager\Model')
                      ->onlyMethods(array('getUser', 'deleteUserAccess', 'setSuperUserAccess'))
                      ->getMock();
         $mock->expects($this->any())->method('getUser')->will($this->returnValue($returnValue));
 
-        $this->userSynchronizer->setUserModel($mock);
+        if ($userSynchronizer) {
+            $userSynchronizer->setUserModel($mock);
+        } else {
+            $this->userSynchronizer->setUserModel($mock);
+        }
     }
 }

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -18,7 +18,6 @@ use Piwik\Config;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UserAccessFilter;
-use Piwik\Tests\Framework\Mock\FakeLogger;
 
 /**
  * @group LoginLdap
@@ -42,6 +41,15 @@ class UserSynchronizerTest extends TestCase
      */
     public $superUserAccess;
 
+    /**
+     * @var array
+     */
+    public $deleteUserAccess;
+    /**
+     * @var array
+     */
+    public $deleteSuperUserAccess;
+
     public function setUp(): void
     {
         $this->userSynchronizer = new UserSynchronizer();
@@ -51,6 +59,12 @@ class UserSynchronizerTest extends TestCase
 
         $this->userAccess = array();
         $this->superUserAccess = array();
+        $this->deleteUserAccess = array();
+        $this->deleteSuperUserAccess = array();
+
+        $config = Config::getInstance()->LoginLdap;
+        $config['enable_synchronize_access_from_ldap'] = 1;
+        Config::getInstance()->LoginLdap = $config;
     }
 
     public function test_makeConfigured_DoesNotThrow_WhenUserMapperCorrectlyConfigured()
@@ -140,19 +154,14 @@ class UserSynchronizerTest extends TestCase
 
     public function test_synchronizePiwikAccessFromLdap_WillNotRemoveAccessWhenAccessEmptyButSyncDisabled()
     {
-        $logger = new FakeLogger();
-        $userSynchronizer = new UserSynchronizer($logger);
-        $this->setUserModelMock($this->getPiwikUserData(), $userSynchronizer);
-        $this->setUserMapperMock($this->getPiwikUserData(), $userSynchronizer);
-        $this->setUserManagerApiMock($throwsOnAdd = false, false, false, $userSynchronizer);
-
+        $this->setUserManagerApiMock($throwsOnAdd = false);
         // First iteration returns mapping
         $this->setUserAccessMapperMock(array(
             'superuser' => array(7,8,9),
             'view' => array(1,2,3),
             'admin' => array(4,5,6)
-        ), $userSynchronizer);
-        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        ));
+        $this->userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
         // Verify access mapping is present
         $this->assertEquals(array(
             array('piwikuser', 'view', array(1,2,3)),
@@ -167,28 +176,25 @@ class UserSynchronizerTest extends TestCase
         $oldValue = $config['enable_synchronize_access_from_ldap'] ?? 0;
         $config['enable_synchronize_access_from_ldap'] = 0;
         Config::getInstance()->LoginLdap = $config;
-        $this->setUserAccessMapperMock([], $userSynchronizer);
-        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
-        $this->assertEmpty($logger->output);
+        $this->setUserAccessMapperMock([]);
+        $this->userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        $this->assertEmpty($this->deleteUserAccess);
+        $this->assertEmpty($this->deleteSuperUserAccess);
+
         $config['enable_synchronize_access_from_ldap'] = $oldValue;
         Config::getInstance()->LoginLdap = $config;
     }
 
     public function test_synchronizePiwikAccessFromLdap_WillRemoveAccessWhenAccessEmptyAndSyncEnabled()
     {
-        $logger = new FakeLogger();
-        $userSynchronizer = new UserSynchronizer($logger);
-        $this->setUserModelMock($this->getPiwikUserData(), $userSynchronizer);
-        $this->setUserMapperMock($this->getPiwikUserData(), $userSynchronizer);
-        $this->setUserManagerApiMock($throwsOnAdd = false, false, false, $userSynchronizer);
-
+        $this->setUserManagerApiMock($throwsOnAdd = false);
         // First iteration returns mapping
         $this->setUserAccessMapperMock(array(
             'superuser' => array(7,8,9),
             'view' => array(1,2,3),
             'admin' => array(4,5,6)
-        ), $userSynchronizer);
-        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        ));
+        $this->userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
         // Verify access mapping is present
         $this->assertEquals(array(
             array('piwikuser', 'view', array(1,2,3)),
@@ -198,14 +204,16 @@ class UserSynchronizerTest extends TestCase
             array('piwikuser', true)
         ), $this->superUserAccess);
 
-        // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=1, it should delete access
+        // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=0, it should do nothing
         $config = Config::getInstance()->LoginLdap;
         $oldValue = $config['enable_synchronize_access_from_ldap'] ?? 0;
         $config['enable_synchronize_access_from_ldap'] = 1;
         Config::getInstance()->LoginLdap = $config;
-        $this->setUserAccessMapperMock([], $userSynchronizer);
-        $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
-        $this->assertStringContainsString("UserSynchronizer::synchronizePiwikAccessFromLdap: User 'piwikuser' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", $logger->output);
+        $this->setUserAccessMapperMock([]);
+        $this->userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
+        $this->assertEquals(['piwikuser'], $this->deleteUserAccess);
+        $this->assertEquals(['piwikuser'], $this->deleteSuperUserAccess);
+
         $config['enable_synchronize_access_from_ldap'] = $oldValue;
         Config::getInstance()->LoginLdap = $config;
     }
@@ -220,7 +228,7 @@ class UserSynchronizerTest extends TestCase
         $this->assertEquals(array(), $this->superUserAccess);
     }
 
-    private function setUserManagerApiMock($throwsOnAddUser, $throwsOnUpdateUser = false, $throwsOnSetAccess = false, &$userSynchronizer = null)
+    private function setUserManagerApiMock($throwsOnAddUser, $throwsOnUpdateUser = false, $throwsOnSetAccess = false)
     {
         $self = $this;
         $model = new Model();
@@ -238,20 +246,26 @@ class UserSynchronizerTest extends TestCase
             $mock->expects($this->any())->method('setUserAccess')->willThrowException(new Exception("dummy message"));
         } else {
             $mock->expects($this->any())->method('setUserAccess')->willReturnCallback(function ($login, $access, $sites) use ($self) {
+                $key = array_search($login, $self->deleteUserAccess);
+                if ($key !== false) {
+                    unset($self->deleteUserAccess[$key]);
+                    $self->deleteUserAccess = array_values($self->deleteUserAccess);
+                }
                 $self->userAccess[] = array($login, $access, $sites);
             });
         }
 
         // for previous version
         $mock->expects($this->any())->method('setSuperUserAccess')->willReturnCallback(function ($login, $hasSuperUserAccess) use ($self) {
+            $key = array_search($login, $self->deleteSuperUserAccess);
+            if ($key !== false && $hasSuperUserAccess) {
+                unset($self->deleteSuperUserAccess[$key]);
+                $self->deleteSuperUserAccess = array_values($self->deleteSuperUserAccess);
+            }
             $self->superUserAccess[] = array($login, $hasSuperUserAccess);
         });
 
-        if ($userSynchronizer) {
-            $userSynchronizer->setUsersManagerApi($mock);
-        } else {
-            $this->userSynchronizer->setUsersManagerApi($mock);
-        }
+        $this->userSynchronizer->setUsersManagerApi($mock);
 
         $mock = $this->getMockBuilder('Piwik\Plugins\UsersManager\UserUpdater')
             ->onlyMethods(array('updateUserWithoutCurrentPassword', 'setSuperUserAccessWithoutCurrentPassword'))
@@ -263,14 +277,15 @@ class UserSynchronizerTest extends TestCase
         }
 
         $mock->expects($this->any())->method('setSuperUserAccessWithoutCurrentPassword')->willReturnCallback(function ($login, $hasSuperUserAccess) use ($self) {
+            $key = array_search($login, $self->deleteSuperUserAccess);
+            if ($key !== false && $hasSuperUserAccess) {
+                unset($self->deleteSuperUserAccess[$key]);
+                $self->deleteSuperUserAccess = array_values($self->deleteSuperUserAccess);
+            }
             $self->superUserAccess[] = array($login, $hasSuperUserAccess);
         });
 
-        if ($userSynchronizer) {
-            $userSynchronizer->setUserUpdater($mock);
-        } else {
-            $this->userSynchronizer->setUserUpdater($mock);
-        }
+        $this->userSynchronizer->setUserUpdater($mock);
     }
 
     private function getPiwikUserData()
@@ -282,7 +297,7 @@ class UserSynchronizerTest extends TestCase
         );
     }
 
-    private function setUserMapperMock($value, $throws = false, &$userSynchronizer = null)
+    private function setUserMapperMock($value, $throws = false)
     {
         $mock = $this->getMockBuilder('Piwik\Plugins\LoginLdap\LdapInterop\UserMapper')
                      ->onlyMethods(array('createPiwikUserFromLdapUser', 'markUserAsLdapUser'))
@@ -292,37 +307,34 @@ class UserSynchronizerTest extends TestCase
         } else {
             $mock->expects($this->any())->method('createPiwikUserFromLdapUser')->will($this->returnValue($value));
         }
-        if ($userSynchronizer) {
-            $userSynchronizer->setUserMapper($mock);
-        } else {
-            $this->userSynchronizer->setUserMapper($mock);
-        }
+        $this->userSynchronizer->setUserMapper($mock);
     }
 
-    private function setUserAccessMapperMock($value, &$userSynchronizer = null)
+    private function setUserAccessMapperMock($value)
     {
         $mock = $this->getMockBuilder('Piwik\Plugins\LoginLdap\LdapInterop\UserAccessMapper')
                      ->onlyMethods(array('getPiwikUserAccessForLdapUser'))
                      ->getMock();
         $mock->expects($this->any())->method('getPiwikUserAccessForLdapUser')->will($this->returnValue($value));
-        if ($userSynchronizer) {
-            $userSynchronizer->setUserAccessMapper($mock);
-        } else {
-            $this->userSynchronizer->setUserAccessMapper($mock);
-        }
+        $this->userSynchronizer->setUserAccessMapper($mock);
     }
 
-    private function setUserModelMock($returnValue, &$userSynchronizer = null)
+    private function setUserModelMock($returnValue)
     {
         $mock = $this->getMockBuilder('Piwik\Plugins\UsersManager\Model')
                      ->onlyMethods(array('getUser', 'deleteUserAccess', 'setSuperUserAccess'))
                      ->getMock();
         $mock->expects($this->any())->method('getUser')->will($this->returnValue($returnValue));
+        $self = $this;
+        $mock->expects($this->any())->method('deleteUserAccess')->willReturnCallback(function ($login) use ($self) {
+            $self->deleteUserAccess[] = $login;
+        });
+        $mock->expects($this->any())->method('setSuperUserAccess')->willReturnCallback(function ($login, $hasSuperUserAccess) use ($self) {
+            if (!$hasSuperUserAccess && !in_array($login, $self->deleteSuperUserAccess)) {
+                $self->deleteSuperUserAccess[] = $login;
+            }
+        });
 
-        if ($userSynchronizer) {
-            $userSynchronizer->setUserModel($mock);
-        } else {
-            $this->userSynchronizer->setUserModel($mock);
-        }
+        $this->userSynchronizer->setUserModel($mock);
     }
 }

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -164,11 +164,14 @@ class UserSynchronizerTest extends TestCase
 
         // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=0, it should do nothing
         $config = Config::getInstance()->LoginLdap;
+        $oldValue = $config['enable_synchronize_access_from_ldap'];
         $config['enable_synchronize_access_from_ldap'] = 0;
         Config::getInstance()->LoginLdap = $config;
         $this->setUserAccessMapperMock([], $userSynchronizer);
         $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
         $this->assertEmpty($logger->output);
+        $config['enable_synchronize_access_from_ldap'] = $oldValue;
+        Config::getInstance()->LoginLdap = $config;
     }
 
     public function test_synchronizePiwikAccessFromLdap_WillRemoveAccessWhenAccessEmptyAndSyncEnabled()
@@ -197,11 +200,14 @@ class UserSynchronizerTest extends TestCase
 
         // Second iteration returns no mapping for the user and since enable_synchronize_access_from_ldap=1, it should delete access
         $config = Config::getInstance()->LoginLdap;
+        $oldValue = $config['enable_synchronize_access_from_ldap'];
         $config['enable_synchronize_access_from_ldap'] = 1;
         Config::getInstance()->LoginLdap = $config;
         $this->setUserAccessMapperMock([], $userSynchronizer);
         $userSynchronizer->synchronizePiwikAccessFromLdap('piwikuser', array());
         $this->assertStringContainsString("UserSynchronizer::synchronizePiwikAccessFromLdap: User 'piwikuser' has no access in LDAP, but access synchronization is enabled. Deleting access if any present.", $logger->output);
+        $config['enable_synchronize_access_from_ldap'] = $oldValue;
+        Config::getInstance()->LoginLdap = $config;
     }
 
     public function test_synchronizePiwikAccessFromLdap_Succeeds_IfLdapUserHasNoAccess()


### PR DESCRIPTION
## Description
Adds code to delete all the access if no access returned from Ldap and enable_synchronize_access_from_ldap=1

## Issue No
#PG-4868

## Steps to Replicate the Issue
1. Enable sync access from ldap
2. Map the access in Ldap for a user
3. Login via that user
4. Now remove all the access for that user in LDAP and try logging in, it will work
5. Checkout this PR
6. Logout and Login again with that user.



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
