### PR TITLE
Restrict isLDAPUser preference, updateUser set via API and set token correctly on login, Fixes #AS-466, #AS-467

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -352,14 +352,13 @@ abstract class Base implements Auth
         if (empty($userInfo['login'])) {
             throw new Exception('User couldn\'t be found');
         }
-
-        $tokenAuth = $this->getTokenAuth();
+        $tokenAuth = $this->usersModel->generateRandomTokenAuth();
         return new AuthResult($successCode, $userInfo['login'], $tokenAuth);
     }
 
     protected function makeAuthFailure()
     {
-        return new AuthResult(AuthResult::FAILURE, $this->login, $this->getTokenAuth());
+        return new AuthResult(AuthResult::FAILURE, $this->login, null);
     }
 
     protected function authenticateByLdap()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LoginLdap Changelog
 
-#### LoginLdap 5.1.5 - 2025-01-26
+#### LoginLdap 5.1.5 - 2025-01-27
 * Restrict isLDAPUser preference set only via internal methods and not via API
 * Set random token value on successful authenticate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.1.5 - 2025-01-26
+* Restrict isLDAPUser preference set only via internal methods and not via API
+* Set random token value on successful authenticate
+
 #### LoginLdap 5.1.4 - 2025-01-12
 * Added code to delete all the access if no access returned from Ldap and enable_synchronize_access_from_ldap=1
 

--- a/LdapInterop/UserMapper.php
+++ b/LdapInterop/UserMapper.php
@@ -29,6 +29,8 @@ class UserMapper
 
     public const USER_PREFERENCE_NAME_IS_LDAP_USER = 'isLDAPUser';
 
+    public static $isLdapPreferenceSetAllowed = false;
+
     /**
      * The LDAP resource field that holds a user's username.
      *
@@ -327,6 +329,7 @@ class UserMapper
     public function markUserAsLdapUser($userLogin)
     {
         Access::doAsSuperUser(function () use ($userLogin) {
+            UserMapper::$isLdapPreferenceSetAllowed = true;
             $class     = Request::getClassNameAPI('UsersManager');
             $parameters = array(
                 'userLogin'       => $userLogin,
@@ -335,6 +338,7 @@ class UserMapper
 
             );
             Proxy::getInstance()->call($class, 'setUserPreference', $parameters);
+            UserMapper::$isLdapPreferenceSetAllowed = false;
         });
     }
 

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -107,6 +107,7 @@ class UserSynchronizer
      * @var bool
      */
     public static $skipPasswordConfirmation = false;
+    public static $allowUpdateUser = false;
 
     public function __construct(?LoggerInterface $logger = null)
     {
@@ -159,8 +160,10 @@ class UserSynchronizer
                 } else {
                     if (Config::getShouldSynchronizeUsersAfterLogin()) {
                         $usersManagerApi::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = false;
+                        self::$allowUpdateUser = true;
                         $usersManagerApi->updateUser($user['login'], $user['password'], $user['email'], $isPasswordHashed = true, true);
                         $usersManagerApi::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = true;
+                        self::$allowUpdateUser = false;
                     } else {
                         $userUpdater->updateUserWithoutCurrentPassword($user['login'], $user['password'], $user['email'], $isPasswordHashed = true);
                     }

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -47,6 +47,7 @@ class LoginLdap extends \Piwik\Plugin
             'UsersManager.checkPassword'             => 'checkPassword',
             'UsersManager.deleteUser'                => 'onUserDeleted',
             'API.UsersManager.setUserPreference'     => 'checkIfUserPreferenceChangeIsAllowed',
+            'API.UsersManager.updateUser'            => 'disablePasswordUpdate',
             'Login.userRequiresPasswordConfirmation' => 'skipPasswordConfirmation',
         );
         return $hooks;
@@ -317,5 +318,12 @@ class LoginLdap extends \Piwik\Plugin
             $passwordVerify = StaticContainer::get('Piwik\Plugins\Login\PasswordVerifier');
             $passwordVerify->setPasswordVerifiedCorrectly();
         }
+    }
+
+    public function disablePasswordUpdate($values)
+    {
+       if (!UserSynchronizer::$allowUpdateUser &&!empty($values['userLogin']) && !empty($values['password']) && $this->isUserLdapUser($values['userLogin'])) {
+           throw new Exception(Piwik::translate('LoginLdap_LdapUserCantChangePassword'));
+       }
     }
 }

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -46,6 +46,7 @@ class LoginLdap extends \Piwik\Plugin
             'Controller.Login.confirmPassword'       => 'checkIfPasswordConfirmationCanBeSkipped',
             'UsersManager.checkPassword'             => 'checkPassword',
             'UsersManager.deleteUser'                => 'onUserDeleted',
+            'API.UsersManager.setUserPreference'     => 'checkIfUserPreferenceChangeIsAllowed',
             'Login.userRequiresPasswordConfirmation' => 'skipPasswordConfirmation',
         );
         return $hooks;
@@ -292,6 +293,20 @@ class LoginLdap extends \Piwik\Plugin
         if ($this->isUserLdapUser($userLogin)) {
             $key = $userLogin . UsersManagerAPI::OPTION_NAME_PREFERENCE_SEPARATOR . UserMapper::USER_PREFERENCE_NAME_IS_LDAP_USER;
             Option::delete($key);
+        }
+    }
+
+    /**
+     * Throws exception if trying to change isLDAPUser preference, which is not allowed via API
+     *
+     * @param $preferenceInfo
+     * @return void
+     * @throws Exception
+     */
+    public function checkIfUserPreferenceChangeIsAllowed($preferenceInfo)
+    {
+        if (isset($preferenceInfo['preferenceName']) && $preferenceInfo['preferenceName'] === UserMapper::USER_PREFERENCE_NAME_IS_LDAP_USER && !UserMapper::$isLdapPreferenceSetAllowed) {
+            throw new Exception(Piwik::translate('LoginLdap_LdapUserCantChangeIsLdapUserPreference'));
         }
     }
 

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -322,8 +322,8 @@ class LoginLdap extends \Piwik\Plugin
 
     public function disablePasswordUpdate($values)
     {
-       if (!UserSynchronizer::$allowUpdateUser &&!empty($values['userLogin']) && !empty($values['password']) && $this->isUserLdapUser($values['userLogin'])) {
-           throw new Exception(Piwik::translate('LoginLdap_LdapUserCantChangePassword'));
-       }
+        if (!UserSynchronizer::$allowUpdateUser && !empty($values['userLogin']) && !empty($values['password']) && $this->isUserLdapUser($values['userLogin'])) {
+            throw new Exception(Piwik::translate('LoginLdap_LdapUserCantChangePassword'));
+        }
     }
 }

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -311,19 +311,25 @@ class LoginLdap extends \Piwik\Plugin
         }
     }
 
+    /**
+     * Throws exception if trying to change password of LDAP user
+     * @param $values
+     * @return void
+     * @throws Exception
+     */
+    public function disablePasswordUpdate($values)
+    {
+        if (!UserSynchronizer::$allowUpdateUser && !empty($values['userLogin']) && !empty($values['password']) && $this->isUserLdapUser($values['userLogin'])) {
+            throw new Exception(Piwik::translate('LoginLdap_LdapUserCantChangePassword'));
+        }
+    }
+
     public function checkIfPasswordConfirmationCanBeSkipped()
     {
         $enablePasswordConfirmation = \Piwik\Plugins\LoginLdap\Config::getConfigOption('enable_password_confirmation');
         if (!$enablePasswordConfirmation) {
             $passwordVerify = StaticContainer::get('Piwik\Plugins\Login\PasswordVerifier');
             $passwordVerify->setPasswordVerifiedCorrectly();
-        }
-    }
-
-    public function disablePasswordUpdate($values)
-    {
-        if (!UserSynchronizer::$allowUpdateUser && !empty($values['userLogin']) && !empty($values['password']) && $this->isUserLdapUser($values['userLogin'])) {
-            throw new Exception(Piwik::translate('LoginLdap_LdapUserCantChangePassword'));
         }
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -89,6 +89,7 @@
         "MobileAppIntegrationNote": "Note: If you plan on using LDAP with the official mobile app, you must keep this option unchecked. Currently, the mobile app cannot authenticate users if user passwords are not stored in Matomo's DB.",
         "PasswordFieldHelp": "Enter a password to overwrite the existing password or leave blank to make no change.",
         "LdapUserCantChangePassword": "Changing your password is not supported for LDAP users. As you use LDAP, your user settings are managed in LDAP directly. For more information, please contact your LDAP server administrator or your Matomo administrator.",
+        "LdapUserCantChangeIsLdapUserPreference": "Changing isLDAPUser preference is not allowed.",
         "StartTLS": "Enable TLS",
         "StartTLSFieldHelp": "To activate TLS for this server",
         "OptionsPWCONFIRMATION": "Enable password confirmation",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],


### PR DESCRIPTION
## Description
Restrict isLDAPUser preference, updateUser set via API and set token correctly on login

## Issue No
#AS-466
#AS-467

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✖] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
