### PR TITLE
destroy all sessions on plugin deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # LoginLdap Changelog
 
-#### LoginLdap 5.1.7 - 2026-02-02   
-* Use new session method to destroy all sessions on plugin deactivation
-
 #### LoginLdap 5.1.6 - 2026-02-02
 * Fixes regression introduced in version 5.1.5 due to restrict actions
+* Use new session method to destroy all sessions on plugin deactivation
 
 #### LoginLdap 5.1.5 - 2026-01-27
 * Restrict isLDAPUser preference set only via internal methods and not via API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # LoginLdap Changelog
 
-#### LoginLdap 5.1.6 - 2025-02-02
+#### LoginLdap 5.1.7 - 2026-01-30
+* Use new session method to destroy all sessions on plugin deactivation
+
+#### LoginLdap 5.1.6 - 2026-02-02
 * Fixes regression introduced in version 5.1.5 due to restrict actions
 
-#### LoginLdap 5.1.5 - 2025-01-27
+#### LoginLdap 5.1.5 - 2026-01-27
 * Restrict isLDAPUser preference set only via internal methods and not via API
 * Set random token value on successful authenticate
 
-#### LoginLdap 5.1.4 - 2025-01-12
+#### LoginLdap 5.1.4 - 2026-01-12
 * Added code to delete all the access if no access returned from Ldap and enable_synchronize_access_from_ldap=1
 
 #### LoginLdap 5.1.3 - 2025-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LoginLdap Changelog
 
-#### LoginLdap 5.1.7 - 2026-01-30
+#### LoginLdap 5.1.7 - 2026-02-02   
 * Use new session method to destroy all sessions on plugin deactivation
 
 #### LoginLdap 5.1.6 - 2026-02-02

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -22,6 +22,7 @@ use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\View;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
+use Piwik\Session;
 
 /**
  *
@@ -166,6 +167,9 @@ class LoginLdap extends \Piwik\Plugin
     {
         if (Manager::getInstance()->isPluginActivated("Login") == false) {
             Manager::getInstance()->activatePlugin("Login");
+        }
+        if (method_exists(Session::class, 'destroyAllSessions')) {
+            Session::destroyAllSessions();
         }
     }
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.1.6",
+    "version": "5.1.7",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.1.7",
+    "version": "5.1.6",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],


### PR DESCRIPTION
## Description
Uses new session method to destroy all sessions on plugin deactivation.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
